### PR TITLE
[Delivers #50116243] Process head tags properly

### DIFF
--- a/lib/polytexnic-core/postprocessor.rb
+++ b/lib/polytexnic-core/postprocessor.rb
@@ -248,15 +248,17 @@ module Polytexnic
         end
       end
 
+
+      # Given a section node, process the <head> tag.
+      # Supports chapter, section, and subsection.
       def make_headings(doc, node, name)
-        node.xpath('.//head').each do |head_node|
-          head_node.name = name
-          a = doc.create_element 'a'
-          a['href'] = "##{node['id']}"
-          a['class'] = 'heading'
-          a << head_node.children
-          head_node << a
-        end
+        head_node = node.children.first
+        head_node.name = name
+        a = doc.create_element 'a'
+        a['href'] = "##{node['id']}"
+        a['class'] = 'heading'
+        a << head_node.children
+        head_node << a
       end
 
       def chapters_and_section(doc)

--- a/spec/polytexnic-core_spec.rb
+++ b/spec/polytexnic-core_spec.rb
@@ -200,14 +200,20 @@ lorem ipsum
 
     describe '\subsection' do
       let(:polytex) do <<-'EOS'
-          \subsection{Foo}
-          \label{subsec:foo}
+          \section{Foo}
+          \label{sec:foo}
+
+          \subsection{Bar}
+          \label{sec:bar}
         EOS
       end
 
       let(:output) do <<-'EOS'
-        <div id="subsec-foo" data-tralics-id="uid1" class="subsection" data-number="1.1.1">
-          <h4><a href="#subsec-foo" class="heading">Foo</a></h4>
+        <div id="sec-foo" data-tralics-id="cid1" class="section" data-number="1.1">
+          <h3><a href="#sec-foo" class="heading"><span class="number">1.1</span>Foo</a></h3>
+          <div id="sec-bar" data-tralics-id="uid1" class="subsection" data-number="1.1.1">
+            <h4><a href="#sec-bar" class="heading">Bar</a></h4>
+          </div>
         </div>
         EOS
       end


### PR DESCRIPTION
The weird behavior we were seeing in the EPUB links was an actual bug (affecting the HTML as well). The deal was that all the `head` tags inside a given section were being processed. This meant that the LaTeX

``` latex
\section{Foo}
\label{sec:foo}

\subsection{Bar}
\label{sec:bar}
```

was being processed such that the `<head>` tags of both Foo _and_ Bar were being processed in the Foo node. The result was that subsections had the href of the parent section rather than the subsection itself. 
