### PR TITLE
[Delivers #50777749] Use corrected regex for syntax highlighting

### DIFF
--- a/lib/polytexnic-core/literal.rb
+++ b/lib/polytexnic-core/literal.rb
@@ -1,6 +1,9 @@
 module Polytexnic
   module Literal
 
+    # Matches the line for syntax highlighting.
+    LANG_REGEX = /^\s*%=\s+lang:(\w+)/
+
     # Makes the caches for literal environments (including non-ASCII Unicode).
     def make_caches(polytex, format = :html)
       output = []
@@ -26,7 +29,7 @@ module Polytexnic
       latex = format == :latex
       language = nil
       while (line = lines.shift)
-        if line =~ /%=\s+lang:(\w+)/
+        if line =~ LANG_REGEX
           if latex
             output << line
           else
@@ -76,7 +79,7 @@ module Polytexnic
     end
 
     # Converts references to hyperrefs.
-    # We want to convert 
+    # We want to convert
     #   Chapter~\ref{cha:foo}
     # to
     #   \hyperref[cha:foo]{Chapter~\ref{cha:foo}

--- a/lib/polytexnic-core/postprocessors/latex.rb
+++ b/lib/polytexnic-core/postprocessors/latex.rb
@@ -1,3 +1,5 @@
+require 'polytexnic-core/literal'
+
 module Polytexnic
   module Postprocessor
     module Latex
@@ -17,7 +19,7 @@ module Polytexnic
         lines = latex.split("\n")
         output = []
         while (line = lines.shift) do
-          if line =~ /%=\s+lang:(\w+)/
+          if line =~ Polytexnic::Literal::LANG_REGEX
             language = $1
             count = 0
             code = []

--- a/lib/polytexnic-core/preprocessors/latex.rb
+++ b/lib/polytexnic-core/preprocessors/latex.rb
@@ -5,7 +5,7 @@ module Polytexnic
       # Returns LaTeX with hashed versions of verbatim environments.
       def to_hashed_latex
         @polytex = make_caches(@polytex, :latex)
-      end      
+      end
     end
   end
 end

--- a/spec/literal_environments_spec.rb
+++ b/spec/literal_environments_spec.rb
@@ -81,7 +81,7 @@ lorem ipsum
     let(:contents) { '\\Omega' }
 
     it { should resemble contents }
-    it { should resemble '<span class="inline_math">' }    
+    it { should resemble '<span class="inline_math">' }
   end
 
   describe "inline math, TeX-style" do
@@ -93,7 +93,7 @@ $\int_\Omega d\omega = \int_{\partial\Omega} \omega$
     let(:contents) { '\\Omega' }
 
     it { should resemble contents }
-    it { should resemble '<span class="inline_math">' }    
+    it { should resemble '<span class="inline_math">' }
     it { should resemble '\\(' }
   end
 
@@ -102,7 +102,7 @@ $\int_\Omega d\omega = \int_{\partial\Omega} \omega$
 
     it { should resemble '\\Omega' }
     it { should resemble '\\equiv' }
-    it { should resemble '<span class="inline_math">' }    
+    it { should resemble '<span class="inline_math">' }
     it { should resemble '\\(' }
   end
 
@@ -268,7 +268,7 @@ end
 
       it { should resemble 'def foo' }
       it { should resemble '<div class="code">' }
-      it { should_not resemble '\begin{code}' }    
+      it { should_not resemble '\begin{code}' }
     end
 
     describe "with syntax highlighting" do

--- a/spec/polytexnic-core_spec.rb
+++ b/spec/polytexnic-core_spec.rb
@@ -32,6 +32,11 @@ end
       it { should_not resemble 'def foo' }
       it { should resemble '\noindent lorem ipsum' }
 
+      describe "in the middle of a line" do
+        let(:polytex) { 'Use \verb+%= lang:ruby+ to highlight Ruby code' }
+        it { should resemble '\verb' }
+        it { should_not resemble '<div class="highlight">' }
+      end
     end
 
     describe "verbatim environments" do
@@ -49,7 +54,7 @@ end
 \end{Verbatim}
       EOS
       end
-      it { should resemble polytex }      
+      it { should resemble polytex }
     end
 
     describe "hyperref links" do
@@ -164,7 +169,7 @@ lorem ipsum
 <ul>
   <li>Foo</li>
   <li>Bar</li>
-</ul>          
+</ul>
         EOS
       end
     end
@@ -181,7 +186,7 @@ lorem ipsum
       end
       it do
         should resemble <<-'EOS'
-<p>lorem ipsum</p>    
+<p>lorem ipsum</p>
 <ul>
   <li>Foo</li>
   <li>Bar</li>
@@ -224,7 +229,7 @@ lorem ipsum
 <ol>
   <li>Foo</li>
   <li>Bar</li>
-</ol>          
+</ol>
         EOS
       end
     end
@@ -362,7 +367,7 @@ lorem ipsum
         EOS
       end
 
-      it do      
+      it do
         pending
         should resemble <<-'EOS'
 <div id="cha-foo" data-tralics-id="cid1" class="chapter" data-number="1">


### PR DESCRIPTION
The key is that the '%= lang:<language>' syntax has to start a line,
which means the regex should allow at most whitespace to precede the
comment character '%'.
