### PR TITLE
Fix for empty code fences

### DIFF
--- a/lib/polytexnic/utils.rb
+++ b/lib/polytexnic/utils.rb
@@ -206,8 +206,8 @@ module Polytexnic
         end
       end
       unless styles.nil?
-        string.gsub!("\\begin{Verbatim}[",
-                     "\\begin{Verbatim}[#{styles},")
+        string.to_s.gsub!("\\begin{Verbatim}[",
+                          "\\begin{Verbatim}[#{styles},")
       end
       string
     end
@@ -226,7 +226,7 @@ module Polytexnic
     # How many? I literally had to just keep adding backslashes until
     # the output was correct when running `softcover build:pdf`.
     def horrible_backslash_kludge(string)
-      string.gsub!(/commandchars=\\\\/, 'commandchars=\\\\\\\\')
+      string.to_s.gsub!(/commandchars=\\\\/, 'commandchars=\\\\\\\\')
     end
 
     # Returns true if we are debugging, false otherwise.


### PR DESCRIPTION
When there's an empty code fence, polytexnic breaks:

```
/usr/local/var/rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/polytexnic-0.9.3/lib/polytexnic/utils.rb:209:in `add_font_info': undefined method `gsub!' for nil:NilClass (NoMethodError)
    from /usr/local/var/rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/polytexnic-0.9.3/lib/polytexnic/utils.rb:141:in `block (2 levels) in highlight_source_code'
...
```

To replicate, I'm just doing something like (where ' is a back tick)

'''ruby
'''
