### PR TITLE
Fixes RegEx in remove_comments

### DIFF
--- a/lib/polytexnic/preprocessors/html.rb
+++ b/lib/polytexnic/preprocessors/html.rb
@@ -122,11 +122,11 @@ module Polytexnic
         # Removes commented-out lines.
         # Contents of the special sequence `%=` are converted to literal HTML.
         def remove_comments(output)
-          output.gsub!(/[^\\]%[^=].*$/, '')
-          output.gsub!(/[^\\]%=(.*)$/) do
-            key = digest($1)
-            literal_html_cache[key] = $1
-            xmlelement('literalhtml') { key }
+          output.gsub!(/([^\\])%([^=]?.)*?\n/, '\1')
+          output.gsub!(/([^\\])%=(.*?)\n/) do
+            key = digest($2)
+            literal_html_cache[key] = $2
+            $1 + xmlelement('literalhtml') { key } + "\n"
           end
         end
 

--- a/spec/to_html/core_spec.rb
+++ b/spec/to_html/core_spec.rb
@@ -9,6 +9,7 @@ describe 'Polytexnic::Pipeline#to_html' do
     let(:polytex) { "% A LaTeX comment" }
     it { should eq '' }
 
+    # FAILS
     context "with a section and label" do
       let(:polytex) do <<-'EOS'
         % \section{Foo}
@@ -17,6 +18,19 @@ describe 'Polytexnic::Pipeline#to_html' do
       end
       it { should eq '' }
     end
+
+    # FAILS
+    context "with a section and label with newline " do
+      let(:polytex) { "% \\section{Foo}\n% \\label{sec:foo}\n" }
+      it { should eq '' }
+    end
+
+    # OK
+    context "with a section and label with newline " do
+      let(:polytex) { "% \\section{Foo}\n% aa a bb\n" }
+      it { should eq '' }
+    end
+
 
     context "with a code listing" do
       let(:polytex) do <<-'EOS'
@@ -71,11 +85,13 @@ describe 'Polytexnic::Pipeline#to_html' do
 
     context "with a percent-equals" do
 
+      # FAILS
       context "with an opening tag" do
         let(:polytex) { '%= <span id="foo" class="bar">' }
         it { should eq '<span id="foo" class="bar">' }
       end
 
+      # FAILS
       context "with a closing tag" do
         let(:polytex) { '%= </span>' }
         it { should eq '</span>' }

--- a/spec/to_html/literal_environments/math_spec.rb
+++ b/spec/to_html/literal_environments/math_spec.rb
@@ -23,6 +23,85 @@ describe Polytexnic::Pipeline do
       EOS
     end
 
+    context "comment removal takes newline with it" do
+      let(:polytex)  { "something % followed by comment\ncontinues"}
+      let(:contents) { "<p>something continues\n</p>"}
+
+      it { should resemble contents }
+    end
+
+    # bcs =$ in comment used to fail...
+    context "math followed by comment with math in it" do
+      let(:polytex)  { "some % comment =$\nmore $\\xi$ fin"}
+      let(:contents) { "<p>some more <span class=\"inline_math\">\\( \\xi \\)</span> fin</p>"}
+
+      it { should resemble contents }
+    end
+
+    context "newlines in inline math" do
+      let(:equation) { "$\\sin\\theta\n\\cos\\theta$" }
+      let(:polytex)  { equation }
+      let(:contents) { "\\( \\sin\\theta\n\\cos\\theta \\)"}
+
+      it { should resemble contents }
+    end
+
+    context "comments in inline math" do
+      let(:equation) { "$\\sin\\theta % comment\n\\cos\\theta$" }
+      let(:polytex)  { equation }
+      let(:contents) { "\\( \\sin\\theta \\cos\\theta \\)"}
+
+      it { should resemble contents }
+    end
+
+    context "comments in displaystyle math" do
+      let(:equation) { "\\[ \\sin\\theta % a comment\n  % = mo comment \n\\cos\\theta \\]" }
+      let(:polytex)  { equation }
+      let(:contents) { "\\[ \\sin\\theta \n\\cos\\theta \\]"}
+
+      it { should resemble contents }
+    end
+
+    context "comment followed by displaystyle math" do
+      let(:equation) { "something\n% a comment\n\\[ \\sin\\theta \\]" }
+      let(:polytex)  { equation }
+      let(:contents) { "<p>something</p>\n<div class=\"equation\">\\[ \\sin\\theta \\]"}
+
+      it { should resemble contents }
+    end
+
+    context "multiline comment followed by displaystyle math" do
+      let(:equation) { "something:\n\t% c line1\n % c line2\n\t\\[\n\t\t\\cos\\theta\n\t\\]" }
+      let(:polytex)  { equation }
+      let(:contents) { "<p>something:</p>\n<div class=\"equation\">\\[ \n\t\\cos\\theta\n\\]"}
+
+      it { should resemble contents }
+    end
+
+    context "math in comment followed by displaystyle" do
+      let(:polytex)  { "as:\n%$x$\n%$y$:\n%nonmepty\n\\[ \\sin\\theta \\]\nMore $m$." }
+      let(:contents) { "<p>as:</p>\n<div class=\"equation\">\\[ \\sin\\theta \\]\n</div><p class=\"noindent\">More <span class=\"inline_math\">\\( m \\)</span>."}
+
+      it { should resemble contents }
+    end
+
+    context "empty comment line after math in comment" do
+      let(:polytex)  { "as:\n%$x$\n%$y$:\n%\n\\[ \\sin\\theta \\]\nMore $m$." }
+      let(:contents) { "<p>as:</p>\n<div class=\"equation\">\\[ \\sin\\theta \\]\n</div><p class=\"noindent\">More <span class=\"inline_math\">\\( m \\)</span>."}
+
+      it { should resemble contents }
+    end
+
+    # WHAT IS THE DESIRED BEHAVIOUR?
+    # context "non-removable comments also work" do
+    #   let(:polytex)  { "$something %= yada\ncontinues$"}
+    #   let(:contents) { "\\( something \\begin{xmlelement}{literalhtml}63e26c6f0c9fff746a67902d3b49f77897ba9500\\end{xmlelement}\ncontinues</span>\n</p>"}
+    #
+    #   it { should resemble contents }
+    # end
+
+
+
     context "TeX displaystyle" do
       let(:equation) { "$$ #{math} $$"}
       let(:polytex)  { equation }


### PR DESCRIPTION
Context:
- Original RegEx in remove_comments would eat a whitespace in front of it
- Original RegEx would not remove newline after it
- New RegEx seems to work on most cases
- Added tests to make sure it does

I'm not sure what is the intended behaviour for `%=` comments are,
or how to test them: the element `\\begin{xmlelement}{literalhtml}`'s digest changes each time the tests are run.

TODO: Ivan has to cleanup the tests file before ready to merge.
